### PR TITLE
Ignore `runtimeType` when comparing models with entities

### DIFF
--- a/packages/clima_core/lib/equatable.dart
+++ b/packages/clima_core/lib/equatable.dart
@@ -1,0 +1,38 @@
+import 'package:collection/collection.dart';
+
+/// A mixin to help decrease the boilerplate associated with [==] and
+/// [hashCode].
+///
+/// [T] should be the current class.
+///
+/// Example usage:
+/// ```dart
+/// class A with Equatable<A> {
+///   const A(this.b);
+///
+///   final int b;
+///
+///   @override
+///   List<Object> get props => [b];
+/// }
+/// ```
+mixin Equatable<T extends Equatable<T>> {
+  List<Object> get props;
+
+  bool get checkRuntimeType;
+
+  static const _propsEquality = ListEquality(DeepCollectionEquality());
+
+  @override
+  bool operator ==(Object that) =>
+      identical(this, that) ||
+      (that is T &&
+          (checkRuntimeType ? runtimeType == that.runtimeType : true) &&
+          _propsEquality.equals(props, that.props));
+
+  @override
+  int get hashCode => props.fold(
+        checkRuntimeType ? runtimeType.hashCode : 0,
+        (a, b) => a ^ b.hashCode,
+      );
+}

--- a/packages/clima_core/test/equatable_test.dart
+++ b/packages/clima_core/test/equatable_test.dart
@@ -1,0 +1,67 @@
+import 'package:clima_core/equatable.dart';
+import 'package:test/test.dart';
+
+class _Foo with Equatable<_Foo> {
+  _Foo(this.a, this.b, {this.checkRuntimeType = false});
+
+  final String a;
+
+  final int b;
+
+  @override
+  final bool checkRuntimeType;
+
+  @override
+  List<Object> get props => [a, b];
+}
+
+class _Bar extends _Foo {
+  _Bar(String a, int b, {bool checkRuntimeType = false})
+      : super(
+          a,
+          b,
+          checkRuntimeType: checkRuntimeType,
+        );
+}
+
+void main() {
+  group('Equatable', () {
+    // TODO: maybe we should add tests for `hashCode` too.
+    group('==', () {
+      test('returns true for identical objects', () {
+        final obj = _Foo('whatever', 1);
+        expect(obj, obj);
+      });
+
+      test('returns true when props have same values', () {
+        expect(_Foo('bar', 2), _Foo('bar', 2));
+        expect(_Foo('baz', 324), _Foo('baz', 324));
+      });
+
+      test('returns false when props are different', () {
+        expect(_Foo('bar', 3), isNot(_Foo('baz', 3)));
+        expect(_Foo('baz', 2), isNot(_Foo('baz', 3)));
+      });
+
+      test('returns true when given object is of a different type', () {
+        expect(_Foo('bar', 2), isNot('2'));
+        expect(_Foo('fad', 2), isNot(3));
+      });
+
+      test(
+          'returns true when given object is a subtype and checkRuntimeType is false',
+          () {
+        expect(_Foo('1', 2), _Bar('1', 2));
+      });
+
+      test(
+          'returns false when given object is subtype and checkRuntimeType is true',
+          () {
+        expect(
+          _Foo('1', 2, checkRuntimeType: true),
+          isNot(_Bar('1', 2, checkRuntimeType: true)),
+        );
+      });
+    });
+  });
+}

--- a/packages/clima_domain/lib/entities/city.dart
+++ b/packages/clima_domain/lib/entities/city.dart
@@ -1,10 +1,13 @@
-import 'package:equatable/equatable.dart';
+import 'package:clima_core/equatable.dart';
 import 'package:meta/meta.dart';
 
-class City extends Equatable {
+class City with Equatable<City> {
   const City({@required this.name});
 
   final String name;
+
+  @override
+  bool get checkRuntimeType => false;
 
   @override
   List<Object> get props => [name];

--- a/packages/clima_domain/lib/entities/weather.dart
+++ b/packages/clima_domain/lib/entities/weather.dart
@@ -1,7 +1,7 @@
-import 'package:equatable/equatable.dart';
+import 'package:clima_core/equatable.dart';
 import 'package:meta/meta.dart';
 
-class Weather extends Equatable {
+class Weather with Equatable<Weather> {
   /// In degrees Celsius (for now).
   final double temperature;
 
@@ -26,7 +26,6 @@ class Weather extends Equatable {
   final String description;
   final String iconCode;
 
-
   final int time;
   final int sunrise;
   final int sunset;
@@ -47,6 +46,9 @@ class Weather extends Equatable {
     @required this.sunset,
     @required this.humidity,
   });
+
+  @override
+  bool get checkRuntimeType => false;
 
   @override
   List<Object> get props => [

--- a/packages/clima_domain/pubspec.yaml
+++ b/packages/clima_domain/pubspec.yaml
@@ -7,7 +7,6 @@ environment:
   sdk: '>=2.8.1 <3.0.0'
 
 dependencies:
-  equatable: 1.2.5
   dartz: 0.9.2
   riverpod: 0.12.2
   clima_core:


### PR DESCRIPTION
This is done so that models and entities can be interchangeably used. We could perhaps introduce a `modelEquals` method for comparing models.