### PR TITLE
Fix error thrown when invalid city name is given

### DIFF
--- a/packages/clima_data/lib/repos/forecasts_repo_impl.dart
+++ b/packages/clima_data/lib/repos/forecasts_repo_impl.dart
@@ -38,8 +38,8 @@ class ForecastsRepoImpl implements ForecastsRepo {
           .map((model) => model.forecasts);
 
       await forecasts
-          .map(memoizedDataSource.setForecasts)
-          .getOrElse(() => throw Error());
+          .map<Future<void>>(memoizedDataSource.setForecasts)
+          .getOrElse(() async {});
 
       return forecasts;
     }

--- a/packages/clima_data/lib/repos/weather_repo_impl.dart
+++ b/packages/clima_data/lib/repos/weather_repo_impl.dart
@@ -38,8 +38,8 @@ class WeatherRepoImpl implements WeatherRepo {
           .map((model) => model.weather);
 
       await weather
-          .map(memoizedDataSource.setWeather)
-          .getOrElse(() async => throw Error());
+          .map<Future<void>>(memoizedDataSource.setWeather)
+          .getOrElse(() async {});
 
       return weather;
     }


### PR DESCRIPTION
Basically, if a city is invalid, `WeatherRemoteDataSource#getWeather` would return
`InvalidCityName`. The old code would then memoize the weather if it's
not `Left`, but if it is, then an error would be thrown (oversight from
my side). The issue is also present in `ForecastsRepo`, so the change is
made there too.

Fixes #134.

[APK](https://github.com/CentaurusApps/clima/files/6722264/app-release.apk.zip)