### PR TITLE
Remove data source abstract class usage

### DIFF
--- a/packages/clima_data/lib/data_sources/city_local_data_source.dart
+++ b/packages/clima_data/lib/data_sources/city_local_data_source.dart
@@ -6,18 +6,11 @@ import 'package:dartz/dartz.dart';
 import 'package:riverpod/riverpod.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
-abstract class CityLocalDataSource {
-  Future<Either<Failure, CityModel?>> getCity();
-
-  Future<Either<Failure, void>> setCity(City city);
-}
-
-class CityLocalDataSourceImpl implements CityLocalDataSource {
-  CityLocalDataSourceImpl(this._prefs);
+class CityLocalDataSource {
+  CityLocalDataSource(this._prefs);
 
   final SharedPreferences _prefs;
 
-  @override
   Future<Either<Failure, CityModel?>> getCity() async {
     final cityName = _prefs.getString('name');
 
@@ -26,7 +19,6 @@ class CityLocalDataSourceImpl implements CityLocalDataSource {
     return Right(CityModel(City(name: cityName)));
   }
 
-  @override
   Future<Either<Failure, void>> setCity(City city) async {
     await _prefs.setString('name', city.name);
 
@@ -34,5 +26,5 @@ class CityLocalDataSourceImpl implements CityLocalDataSource {
   }
 }
 
-final cityLocalDataSourceProvider = Provider<CityLocalDataSource>(
-    (ref) => CityLocalDataSourceImpl(ref.watch(sharedPreferencesProvider)));
+final cityLocalDataSourceProvider = Provider(
+    (ref) => CityLocalDataSource(ref.watch(sharedPreferencesProvider)));

--- a/packages/clima_data/lib/data_sources/city_random_data_source.dart
+++ b/packages/clima_data/lib/data_sources/city_random_data_source.dart
@@ -6,10 +6,6 @@ import 'package:clima_domain/entities/city.dart';
 import 'package:dartz/dartz.dart';
 import 'package:riverpod/riverpod.dart';
 
-abstract class CityRandomDataSource {
-  Future<Either<Failure, CityModel>> getCity();
-}
-
 const _randomCityNames = [
   'Amsterdam',
   'London',
@@ -28,8 +24,7 @@ const _randomCityNames = [
   'Sydney',
 ];
 
-class CityRandomDataSourceImpl implements CityRandomDataSource {
-  @override
+class CityRandomDataSource {
   Future<Either<Failure, CityModel>> getCity() async => Right(
         CityModel(
           City(
@@ -39,5 +34,4 @@ class CityRandomDataSourceImpl implements CityRandomDataSource {
       );
 }
 
-final cityRandomDataSourceProvider =
-    Provider<CityRandomDataSource>((ref) => CityRandomDataSourceImpl());
+final cityRandomDataSourceProvider = Provider((ref) => CityRandomDataSource());

--- a/packages/clima_data/lib/data_sources/forecast_remote_data_source.dart
+++ b/packages/clima_data/lib/data_sources/forecast_remote_data_source.dart
@@ -8,18 +8,13 @@ import 'package:dartz/dartz.dart';
 import 'package:http/http.dart' as http;
 import 'package:riverpod/riverpod.dart';
 
-abstract class ForecastsRemoteDataSource {
-  Future<Either<Failure, ForecastsModel>> getForecasts(City city);
-}
+class ForecastsRemoteDataSource {
+  ForecastsRemoteDataSource(this._apiKeyRepo);
 
-class ForecastsRemoteDataSourceImpl implements ForecastsRemoteDataSource {
-  ForecastsRemoteDataSourceImpl(this.apiKeyRepo);
+  final ApiKeyRepo _apiKeyRepo;
 
-  final ApiKeyRepo apiKeyRepo;
-
-  @override
   Future<Either<Failure, ForecastsModel>> getForecasts(City city) async {
-    final apiKey = (await apiKeyRepo.getApiKey()).fold((_) => null, id)!;
+    final apiKey = (await _apiKeyRepo.getApiKey()).fold((_) => null, id)!;
 
     final response = await http.get(
       Uri(
@@ -52,5 +47,5 @@ class ForecastsRemoteDataSourceImpl implements ForecastsRemoteDataSource {
   }
 }
 
-final forecastRemoteDataSourceProvider = Provider<ForecastsRemoteDataSource>(
-    (ref) => ForecastsRemoteDataSourceImpl(ref.watch(apiKeyRepoProvider)));
+final forecastRemoteDataSourceProvider =
+    Provider((ref) => ForecastsRemoteDataSource(ref.watch(apiKeyRepoProvider)));

--- a/packages/clima_data/lib/data_sources/forecasts_memoized_data_source.dart
+++ b/packages/clima_data/lib/data_sources/forecasts_memoized_data_source.dart
@@ -5,20 +5,13 @@ import 'package:clima_domain/entities/forecasts.dart';
 import 'package:dartz/dartz.dart';
 import 'package:riverpod/riverpod.dart';
 
-abstract class ForecastsMemoizedDataSource {
-  Future<Either<Failure, void>> setForecasts(Forecasts forecasts);
-
-  Future<Either<Failure, Forecasts?>> getMemoizedForecasts();
-}
-
-class ForecastsMemoizedDataSourceImpl implements ForecastsMemoizedDataSource {
+class ForecastsMemoizedDataSource {
   Forecasts? _forecasts;
 
   DateTime? _fetchingTime;
 
   static const _invalidationDuration = Duration(minutes: 1);
 
-  @override
   Future<Either<Failure, Forecasts?>> getMemoizedForecasts() async {
     if (_forecasts == null) return const Right(null);
 
@@ -39,7 +32,6 @@ class ForecastsMemoizedDataSourceImpl implements ForecastsMemoizedDataSource {
     return Right(_forecasts);
   }
 
-  @override
   Future<Either<Failure, void>> setForecasts(Forecasts forecasts) async {
     _fetchingTime = DateTime.now();
     _forecasts = forecasts;
@@ -48,6 +40,4 @@ class ForecastsMemoizedDataSourceImpl implements ForecastsMemoizedDataSource {
 }
 
 final forecastsMemoizedDataSourceProvider =
-    Provider<ForecastsMemoizedDataSource>(
-  (ref) => ForecastsMemoizedDataSourceImpl(),
-);
+    Provider((ref) => ForecastsMemoizedDataSource());

--- a/packages/clima_data/lib/data_sources/theme_local_data_source.dart
+++ b/packages/clima_data/lib/data_sources/theme_local_data_source.dart
@@ -10,22 +10,11 @@ const String _themeKey = 'app_theme';
 
 const String _darkThemeKey = 'app_dark_theme';
 
-abstract class ThemeLocalDataSource {
-  Future<Either<Failure, ThemeModel?>> getTheme();
-
-  Future<Either<Failure, void>> setTheme(ThemeModel theme);
-
-  Future<Either<Failure, DarkThemeModel?>> getDarkTheme();
-
-  Future<Either<Failure, void>> setDarkTheme(DarkThemeModel theme);
-}
-
-class ThemeLocalDataSourceImpl implements ThemeLocalDataSource {
-  ThemeLocalDataSourceImpl(this._prefs);
+class ThemeLocalDataSource {
+  ThemeLocalDataSource(this._prefs);
 
   final SharedPreferences _prefs;
 
-  @override
   Future<Either<Failure, ThemeModel?>> getTheme() async {
     final string = _prefs.getString(_themeKey);
 
@@ -37,14 +26,12 @@ class ThemeLocalDataSourceImpl implements ThemeLocalDataSource {
     return Right(ThemeModel.parse(string));
   }
 
-  @override
   Future<Either<Failure, void>> setTheme(ThemeModel theme) async {
     await _prefs.setString(_themeKey, theme.toString());
 
     return const Right(null);
   }
 
-  @override
   Future<Either<Failure, DarkThemeModel?>> getDarkTheme() async {
     final string = _prefs.getString(_darkThemeKey);
 
@@ -56,7 +43,6 @@ class ThemeLocalDataSourceImpl implements ThemeLocalDataSource {
     return Right(DarkThemeModel.parse(string));
   }
 
-  @override
   Future<Either<Failure, void>> setDarkTheme(DarkThemeModel theme) async {
     await _prefs.setString(_darkThemeKey, theme.toString());
 
@@ -64,5 +50,5 @@ class ThemeLocalDataSourceImpl implements ThemeLocalDataSource {
   }
 }
 
-final themeLocalDataSourceProvider = Provider<ThemeLocalDataSource>(
-    (ref) => ThemeLocalDataSourceImpl(ref.watch(sharedPreferencesProvider)));
+final themeLocalDataSourceProvider = Provider(
+    (ref) => ThemeLocalDataSource(ref.watch(sharedPreferencesProvider)));

--- a/packages/clima_data/lib/data_sources/weather_memoized_data_source.dart
+++ b/packages/clima_data/lib/data_sources/weather_memoized_data_source.dart
@@ -5,20 +5,13 @@ import 'package:clima_domain/entities/weather.dart';
 import 'package:dartz/dartz.dart';
 import 'package:riverpod/riverpod.dart';
 
-abstract class WeatherMemoizedDataSource {
-  Future<Either<Failure, void>> setWeather(Weather weather);
-
-  Future<Either<Failure, Weather?>> getMemoizedWeather();
-}
-
-class WeatherMemoizedDataSourceImpl implements WeatherMemoizedDataSource {
+class WeatherMemoizedDataSource {
   Weather? _weather;
 
   DateTime? _fetchingTime;
 
   static const _invalidationDuration = Duration(minutes: 1);
 
-  @override
   Future<Either<Failure, Weather?>> getMemoizedWeather() async {
     if (_weather == null) return const Right(null);
 
@@ -39,7 +32,6 @@ class WeatherMemoizedDataSourceImpl implements WeatherMemoizedDataSource {
     return Right(_weather);
   }
 
-  @override
   Future<Either<Failure, void>> setWeather(Weather weather) async {
     _fetchingTime = DateTime.now();
     _weather = weather;
@@ -47,6 +39,5 @@ class WeatherMemoizedDataSourceImpl implements WeatherMemoizedDataSource {
   }
 }
 
-final weatherMemoizedDataSourceProvider = Provider<WeatherMemoizedDataSource>(
-  (ref) => WeatherMemoizedDataSourceImpl(),
-);
+final weatherMemoizedDataSourceProvider =
+    Provider((ref) => WeatherMemoizedDataSource());

--- a/packages/clima_data/lib/data_sources/weather_remote_data_source.dart
+++ b/packages/clima_data/lib/data_sources/weather_remote_data_source.dart
@@ -8,18 +8,13 @@ import 'package:dartz/dartz.dart';
 import 'package:http/http.dart' as http;
 import 'package:riverpod/riverpod.dart';
 
-abstract class WeatherRemoteDataSource {
-  Future<Either<Failure, WeatherModel>> getWeather(City city);
-}
+class WeatherRemoteDataSource {
+  WeatherRemoteDataSource(this._apiKeyRepo);
 
-class WeatherRemoteDataSourceImpl implements WeatherRemoteDataSource {
-  WeatherRemoteDataSourceImpl(this.apiKeyRepo);
+  final ApiKeyRepo _apiKeyRepo;
 
-  final ApiKeyRepo apiKeyRepo;
-
-  @override
   Future<Either<Failure, WeatherModel>> getWeather(City city) async {
-    final apiKey = (await apiKeyRepo.getApiKey()).fold((_) => null, id)!;
+    final apiKey = (await _apiKeyRepo.getApiKey()).fold((_) => null, id)!;
 
     // TODO: create a client as the docs recommend creating a client when
     // making multiple requests to the same server.
@@ -54,5 +49,5 @@ class WeatherRemoteDataSourceImpl implements WeatherRemoteDataSource {
   }
 }
 
-final weatherRemoteDataSourceProvider = Provider<WeatherRemoteDataSource>(
-    (ref) => WeatherRemoteDataSourceImpl(ref.watch(apiKeyRepoProvider)));
+final weatherRemoteDataSourceProvider =
+    Provider((ref) => WeatherRemoteDataSource(ref.watch(apiKeyRepoProvider)));


### PR DESCRIPTION
This is not necessary, as they are in the same file, and if they ever need to be mocked in tests, the "implementation" classes can just be `implement`ed anyway