### PR TITLE
Fix ListView Overscroll Glow Color

### DIFF
--- a/packages/clima_ui/lib/themes/black_theme.dart
+++ b/packages/clima_ui/lib/themes/black_theme.dart
@@ -12,6 +12,7 @@ ThemeData blackTheme = ThemeData.dark().copyWith(
   dialogBackgroundColor: const Color(0xFF202125),
   toggleableActiveColor: const Color(0xFF89B4F8),
   accentColor: const Color(0xFF89B4F8),
+  colorScheme: ColorScheme.fromSwatch(accentColor: const Color(0xFF89B4F8)),
   primaryColor: const Color(0xFF000000),
   scaffoldBackgroundColor: const Color(0xFF000000),
   snackBarTheme: const SnackBarThemeData(

--- a/packages/clima_ui/lib/themes/dark_theme.dart
+++ b/packages/clima_ui/lib/themes/dark_theme.dart
@@ -12,6 +12,7 @@ ThemeData darkGreyTheme = ThemeData.dark().copyWith(
   dialogBackgroundColor: const Color(0xFF202125),
   toggleableActiveColor: const Color(0xFF89B4F8),
   accentColor: const Color(0xFF89B4F8),
+  colorScheme: ColorScheme.fromSwatch(accentColor: const Color(0xFF89B4F8)),
   primaryColor: const Color(0xFF202125),
   scaffoldBackgroundColor: const Color(0xFF202125),
   snackBarTheme: const SnackBarThemeData(

--- a/packages/clima_ui/lib/themes/light_theme.dart
+++ b/packages/clima_ui/lib/themes/light_theme.dart
@@ -10,6 +10,7 @@ ThemeData lightTheme = ThemeData.light().copyWith(
   iconTheme: const IconThemeData(color: Color(0xFF5F6267)),
   toggleableActiveColor: const Color(0xFF1A73E9),
   accentColor: const Color(0xFF1A73E9),
+  colorScheme: ColorScheme.fromSwatch(accentColor: const Color(0xFF1A73E9)),
   primaryColor: const Color(0xFFFFFFFF),
   scaffoldBackgroundColor: const Color(0xFFFFFFFF),
   snackBarTheme: const SnackBarThemeData(


### PR DESCRIPTION
fixes #209

The color of the overscroll glow effect is now defined in the ThemeData.colorScheme.secondary property ([docs](https://api.flutter.dev/flutter/widgets/GlowingOverscrollIndicator-class.html)) as of Flutter 2.2