### PR TITLE
Add current day forecast property to full weather

### DIFF
--- a/packages/clima_data/lib/models/full_weather_model.dart
+++ b/packages/clima_data/lib/models/full_weather_model.dart
@@ -16,22 +16,6 @@ class FullWeatherModel extends Equatable {
     required City city,
   }) {
     final currentWeatherJson = json['current'];
-    final currentTime = currentWeatherJson['dt'] as int;
-
-    final currentDayForecast = (json['daily'] as List).reduce((a, b) {
-      final aDiffCurrent =
-          ((currentWeatherJson['dt'] as int) - (a['dt'] as int)).abs();
-      final bDiffCurrent =
-          ((currentWeatherJson['dt'] as int) - (b['dt'] as int)).abs();
-
-      if (aDiffCurrent < bDiffCurrent) {
-        return a;
-      } else if (bDiffCurrent == aDiffCurrent) {
-        throw Exception("Two daily forecasts can't have the same time");
-      } else {
-        return b;
-      }
-    });
 
     return FullWeatherModel(
       FullWeather(
@@ -39,20 +23,15 @@ class FullWeatherModel extends Equatable {
         timeZoneOffset: Duration(seconds: json['timezone_offset'] as int),
         currentWeather: Weather(
           temperature: (currentWeatherJson['temp'] as num).toDouble(),
-          maxTemperature: (currentDayForecast['temp']['max'] as num).toDouble(),
-          minTemperature: (currentDayForecast['temp']['min'] as num).toDouble(),
           tempFeel: (currentWeatherJson['feels_like'] as num).toDouble(),
           // We multiply by 3.6 to convert from m/s to km/h.
           windSpeed: (currentWeatherJson['wind_speed'] as num).toDouble() * 3.6,
           condition: currentWeatherJson['weather'][0]['id'] as int,
           description:
               currentWeatherJson['weather'][0]['description'] as String,
-          date: date_time_utils.fromUtcUnixTime(currentTime),
+          date:
+              date_time_utils.fromUtcUnixTime(currentWeatherJson['dt'] as int),
           iconCode: currentWeatherJson['weather'][0]['icon'] as String,
-          sunrise: date_time_utils
-              .fromUtcUnixTime(currentWeatherJson['sunrise'] as int),
-          sunset: date_time_utils
-              .fromUtcUnixTime(currentWeatherJson['sunset'] as int),
           humidity: currentWeatherJson['humidity'] as int,
           pressure: currentWeatherJson['pressure'] as int,
           uvIndex: (currentWeatherJson['uvi'] as num).toDouble(),
@@ -66,6 +45,10 @@ class FullWeatherModel extends Equatable {
                     date_time_utils.fromUtcUnixTime(forecastJson['dt'] as int),
                 iconCode: forecastJson['weather'][0]['icon'] as String,
                 pop: (forecastJson['pop'] as num).toDouble(),
+                sunrise: date_time_utils
+                    .fromUtcUnixTime(forecastJson['sunrise'] as int),
+                sunset: date_time_utils
+                    .fromUtcUnixTime(forecastJson['sunset'] as int),
               ),
             )
             .toList(),

--- a/packages/clima_data/test/models/full_weather_model_test.dart
+++ b/packages/clima_data/test/models/full_weather_model_test.dart
@@ -25,8 +25,6 @@ void main() {
         fullWeather.currentWeather,
         Weather(
           date: date_time_utils.fromUtcUnixTime(1634313115),
-          sunrise: date_time_utils.fromUtcUnixTime(1634264178),
-          sunset: date_time_utils.fromUtcUnixTime(1634307772),
           temperature: 27.16,
           tempFeel: 29.5,
           pressure: 1011,
@@ -36,8 +34,6 @@ void main() {
           condition: 800,
           iconCode: "01n",
           description: "clear sky",
-          minTemperature: 26.71,
-          maxTemperature: 27.17,
         ),
       );
 
@@ -51,16 +47,18 @@ void main() {
         ),
       );
 
-      expect(
-        fullWeather.dailyForecasts[0],
-        DailyForecast(
-          date: date_time_utils.fromUtcUnixTime(1634284800),
-          iconCode: '10d',
-          minTemperature: 26.71,
-          maxTemperature: 27.17,
-          pop: 0.24,
-        ),
+      final dailyForecast = DailyForecast(
+        date: date_time_utils.fromUtcUnixTime(1634284800),
+        sunrise: date_time_utils.fromUtcUnixTime(1634264178),
+        sunset: date_time_utils.fromUtcUnixTime(1634307772),
+        iconCode: '10d',
+        minTemperature: 26.71,
+        maxTemperature: 27.17,
+        pop: 0.24,
       );
+
+      expect(fullWeather.dailyForecasts[0], dailyForecast);
+      expect(fullWeather.currentDayForecast, dailyForecast);
     });
   });
 }

--- a/packages/clima_domain/lib/entities/daily_forecast.dart
+++ b/packages/clima_domain/lib/entities/daily_forecast.dart
@@ -3,6 +3,10 @@ import 'package:equatable/equatable.dart';
 class DailyForecast extends Equatable {
   final DateTime date;
 
+  final DateTime sunrise;
+
+  final DateTime sunset;
+
   /// Minimum temperature at the moment. In degrees Celsius (for now).
   final double minTemperature;
 
@@ -16,6 +20,8 @@ class DailyForecast extends Equatable {
 
   const DailyForecast({
     required this.date,
+    required this.sunrise,
+    required this.sunset,
     required this.minTemperature,
     required this.maxTemperature,
     required this.pop,
@@ -24,5 +30,5 @@ class DailyForecast extends Equatable {
 
   @override
   List<Object?> get props =>
-      [date, minTemperature, maxTemperature, pop, iconCode];
+      [date, sunrise, sunset, minTemperature, maxTemperature, pop, iconCode];
 }

--- a/packages/clima_domain/lib/entities/full_weather.dart
+++ b/packages/clima_domain/lib/entities/full_weather.dart
@@ -24,6 +24,23 @@ class FullWeather extends Equatable {
 
   final List<HourlyForecast> hourlyForecasts;
 
+  DailyForecast get currentDayForecast => dailyForecasts.reduce((a, b) {
+        final aDiffCurrent = currentWeather.date.difference(a.date).abs();
+        final bDiffCurrent = currentWeather.date.difference(b.date).abs();
+
+        if (aDiffCurrent < bDiffCurrent) {
+          return a;
+        } else if (bDiffCurrent == aDiffCurrent) {
+          if (a.date.weekday == currentWeather.date.weekday) {
+            return a;
+          }
+
+          return b;
+        } else {
+          return b;
+        }
+      });
+
   @override
   List<Object> get props =>
       [city, timeZoneOffset, currentWeather, dailyForecasts, hourlyForecasts];

--- a/packages/clima_domain/lib/entities/full_weather.dart
+++ b/packages/clima_domain/lib/entities/full_weather.dart
@@ -1,5 +1,6 @@
 import 'package:clima_domain/entities/daily_forecast.dart';
 import 'package:clima_domain/entities/hourly_forecast.dart';
+import 'package:collection/collection.dart';
 import 'package:equatable/equatable.dart';
 
 import 'city.dart';
@@ -24,22 +25,12 @@ class FullWeather extends Equatable {
 
   final List<HourlyForecast> hourlyForecasts;
 
-  DailyForecast get currentDayForecast => dailyForecasts.reduce((a, b) {
-        final aDiffCurrent = currentWeather.date.difference(a.date).abs();
-        final bDiffCurrent = currentWeather.date.difference(b.date).abs();
-
-        if (aDiffCurrent < bDiffCurrent) {
-          return a;
-        } else if (bDiffCurrent == aDiffCurrent) {
-          if (a.date.weekday == currentWeather.date.weekday) {
-            return a;
-          }
-
-          return b;
-        } else {
-          return b;
-        }
-      });
+  DailyForecast get currentDayForecast => minBy(
+        dailyForecasts.where(
+          (forecast) => forecast.date.weekday == currentWeather.date.weekday,
+        ),
+        (forecast) => forecast.date.difference(currentWeather.date).abs(),
+      )!;
 
   @override
   List<Object> get props =>

--- a/packages/clima_domain/lib/entities/weather.dart
+++ b/packages/clima_domain/lib/entities/weather.dart
@@ -3,10 +3,6 @@ import 'package:equatable/equatable.dart';
 class Weather extends Equatable {
   final DateTime date;
 
-  final DateTime sunrise;
-
-  final DateTime sunset;
-
   /// In degrees Celsius (for now).
   final double temperature;
 
@@ -18,12 +14,6 @@ class Weather extends Equatable {
 
   /// Current weather condition (e.g. snow, thunderstorm).
   final int condition;
-
-  /// Minimum temperature at the moment. Same unit as [temperature].
-  final double minTemperature;
-
-  /// Maximum temperature at the moment. Same unit as [temperature].
-  final double maxTemperature;
 
   final int humidity;
 
@@ -39,14 +29,10 @@ class Weather extends Equatable {
 
   const Weather({
     required this.date,
-    required this.sunrise,
-    required this.sunset,
     required this.temperature,
     required this.windSpeed,
     required this.tempFeel,
     required this.condition,
-    required this.minTemperature,
-    required this.maxTemperature,
     required this.humidity,
     required this.pressure,
     required this.uvIndex,
@@ -57,14 +43,10 @@ class Weather extends Equatable {
   @override
   List<Object?> get props => [
         date,
-        sunrise,
-        sunset,
         temperature,
         windSpeed,
         tempFeel,
         condition,
-        minTemperature,
-        maxTemperature,
         humidity,
         pressure,
         uvIndex,

--- a/packages/clima_domain/pubspec.yaml
+++ b/packages/clima_domain/pubspec.yaml
@@ -9,6 +9,7 @@ environment:
 dependencies:
   riverpod: 0.14.0+3
   equatable: 2.0.3
+  collection: 1.15.0
   clima_core:
     path: ../clima_core
 


### PR DESCRIPTION
<!-- Template adapted from [auth0](https://github.com/auth0/open-source-template/blob/master/.github/PULL_REQUEST_TEMPLATE.md) -->

By submitting a PR to this repository, you agree to the terms within our [Code of Conduct](https://github.com/lacerte/clima/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/lacerte/clima/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

> Describe the purpose of this PR along with any background information and the impacts of the proposed change. For the benefit of the community, please do not assume prior context.
>
> Provide details that support your chosen implementation, including: breaking changes, alternatives considered, changes to the API, etc.
>
> If the UI is being changed, please provide screenshots.

Add a `currentDayForecast` property to `FullWeather`.

### Testing

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
