### PR TITLE
Always use string values for query parameters

### DIFF
--- a/packages/clima_data/lib/data_sources/full_weather_remote_data_source.dart
+++ b/packages/clima_data/lib/data_sources/full_weather_remote_data_source.dart
@@ -31,8 +31,8 @@ class FullWeatherRemoteDataSource {
         host: 'api.openweathermap.org',
         path: '/data/2.5/onecall',
         queryParameters: {
-          'lon': coordinates.long,
-          'lat': coordinates.lat,
+          'lon': coordinates.long.toString(),
+          'lat': coordinates.lat.toString(),
           'appid': apiKey,
           'units': 'metric',
         },

--- a/packages/clima_data/lib/data_sources/geocoding_remote_data_source.dart
+++ b/packages/clima_data/lib/data_sources/geocoding_remote_data_source.dart
@@ -27,7 +27,7 @@ class GeocodingRemoteDataSource {
         queryParameters: {
           'q': city.name,
           'appid': apiKey,
-          'limit': 1,
+          'limit': '1',
         },
       ),
     );


### PR DESCRIPTION
This would throw an error otherwise.

<!-- Template adapted from [auth0](https://github.com/auth0/open-source-template/blob/master/.github/PULL_REQUEST_TEMPLATE.md) -->

By submitting a PR to this repository, you agree to the terms within our [Code of Conduct](https://github.com/lacerte/clima/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/lacerte/clima/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description
Don't pass non-string query parameters to `http`, else an error would be thrown (to be precise it also accepts an `Iterable<String>`, but I don't know what that actually means).

### Testing

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
