### PR TITLE
Exclude minutely and alerts from API response

### DIFF
--- a/packages/clima_data/lib/data_sources/full_weather_remote_data_source.dart
+++ b/packages/clima_data/lib/data_sources/full_weather_remote_data_source.dart
@@ -35,6 +35,7 @@ class FullWeatherRemoteDataSource {
           'lat': coordinates.lat,
           'appid': apiKey,
           'units': 'metric',
+          'exclude': 'minutely,alerts',
         },
       ),
     );


### PR DESCRIPTION
<!-- Template adapted from [auth0](https://github.com/auth0/open-source-template/blob/master/.github/PULL_REQUEST_TEMPLATE.md) -->

By submitting a PR to this repository, you agree to the terms within our [Code of Conduct](https://github.com/lacerte/clima/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/lacerte/clima/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

Exclude `minutely` and `alerts` from OpenWeatherMap's API response, to reduce the response size.

### Testing

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
