### PR TITLE
[data] don't assume temperature is a double

### DIFF
--- a/packages/clima_data/lib/models/full_weather_model.dart
+++ b/packages/clima_data/lib/models/full_weather_model.dart
@@ -58,7 +58,7 @@ class FullWeatherModel extends Equatable {
             HourlyForecast(
               date: date_time_utils.fromUtcUnixTime(forecastJson['dt'] as int),
               iconCode: forecastJson['weather'][0]['icon'] as String,
-              temperature: forecastJson['temp'] as double,
+              temperature: (forecastJson['temp'] as num).toDouble(),
               pop: (forecastJson['pop'] as num).toDouble(),
             ),
         ],


### PR DESCRIPTION
<!-- Template adapted from [auth0](https://github.com/auth0/open-source-template/blob/master/.github/PULL_REQUEST_TEMPLATE.md) -->

By submitting a PR to this repository, you agree to the terms within our [Code of Conduct](https://github.com/lacerte/clima/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/lacerte/clima/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description


Fixes an error when the temperature returned by the API is an `int`.

### Testing


- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
