### PR TITLE
Show weather's date in weather screen app bar

### DIFF
--- a/packages/clima_ui/lib/screens/weather_screen.dart
+++ b/packages/clima_ui/lib/screens/weather_screen.dart
@@ -29,6 +29,7 @@ class WeatherScreen extends HookConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final fullWeatherState = ref.watch(w.fullWeatherStateNotifierProvider);
+    final fullWeather = fullWeatherState.fullWeather;
 
     final fullWeatherStateNotifier =
         ref.watch(w.fullWeatherStateNotifierProvider.notifier);
@@ -50,37 +51,39 @@ class WeatherScreen extends HookConsumerWidget {
 
     useEffect(
       () {
-        if (fullWeatherState.fullWeather == null) {
+        if (fullWeather == null) {
           return null;
         }
+
         return cityStateNotifier.addListener((state) {
           if (state is c.Error) {
             showFailureSnackBar(context, failure: state.failure, duration: 2);
           }
         });
       },
-      [cityStateNotifier, fullWeatherState.fullWeather == null],
+      [cityStateNotifier, fullWeather == null],
     );
 
     useEffect(
       () {
-        if (fullWeatherState.fullWeather == null) {
+        if (fullWeather == null) {
           return null;
         }
+
         return fullWeatherStateNotifier.addListener((state) {
           if (state is w.Error) {
             showFailureSnackBar(context, failure: state.failure, duration: 2);
           }
         });
       },
-      [fullWeatherStateNotifier, fullWeatherState.fullWeather],
+      [fullWeatherStateNotifier, fullWeather],
     );
 
     return Scaffold(
       resizeToAvoidBottomInset: false,
       body: FloatingSearchAppBar(
         liftOnScrollElevation: 0.0,
-        elevation: fullWeatherState.fullWeather == null ? 2.0 : 0.0,
+        elevation: fullWeather == null ? 2.0 : 0.0,
         systemOverlayStyle: Theme.of(context).appBarTheme.systemOverlayStyle,
         automaticallyImplyBackButton: false,
         controller: controller,
@@ -100,9 +103,9 @@ class WeatherScreen extends HookConsumerWidget {
           }
         },
         title: Text(
-          fullWeatherState.fullWeather == null
+          fullWeather == null
               ? ''
-              : 'Updated ${DateFormat.Md().add_jm().format(DateTime.now())}',
+              : 'Updated ${DateFormat.Md().add_jm().format(fullWeather.currentWeather.date.toLocal())}',
           style: TextStyle(
             color: Theme.of(context).textTheme.subtitle2!.color,
             fontSize:
@@ -161,13 +164,12 @@ class WeatherScreen extends HookConsumerWidget {
                   }
                 }(),
               ),
-              child: fullWeatherState is w.Error &&
-                      fullWeatherState.fullWeather == null
+              child: fullWeatherState is w.Error && fullWeather == null
                   ? FailureBanner(
                       failure: fullWeatherState.failure,
                       onRetry: fullWeatherStateNotifier.loadFullWeather,
                     )
-                  : fullWeatherState.fullWeather == null
+                  : fullWeather == null
                       ? null
                       : Container(
                           constraints: const BoxConstraints.expand(),


### PR DESCRIPTION
<!-- Template adapted from https://github.com/auth0/open-source-template/blob/master/.github/PULL_REQUEST_TEMPLATE.md -->

<!-- Text between these brackets isn't actually shown to others. Check the preview if you're not sure! -->

<!-- By submitting a PR to this repository, you agree to the terms within our Code of Conduct (https://github.com/lacerte/clima/blob/master/CODE-OF-CONDUCT.md). Please see https://github.com/lacerte/clima/blob/master/CONTRIBUTING.md for how to create and submit a high-quality PR for this repo. -->

~~[app-release.apk.zip](https://github.com/Lacerte/clima/files/7739521/app-release.apk.zip)~~
[app-release.apk.zip](https://github.com/Lacerte/clima/files/7739728/app-release.apk.zip)

### Description

Previously it would call `DateTime.now` directly, which is wrong both
because it can be different from the weather date, and because `build`
methods should never return different results if called with an
identical environment.
<!--
Describe this PR's purpose and impact, along with any background information. Please do not assume prior context.

Provide details that support your chosen implementation, including: breaking changes, alternatives considered, changes to the API, etc. If the UI is being changed, please provide screenshots.
--> 

### References

- Closes #187

### Testing

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this repository has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.

Please include any manual steps for testing any functionality not covered by unit/integration tests.

Also include details of the environment this PR was developed in (device/platform/version).
-->

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] The correct base branch is being used, if not `master`
