### PR TITLE
[ui] don't show temperature unit in app bar if weather is null

### DIFF
--- a/packages/clima_ui/lib/screens/weather_screen.dart
+++ b/packages/clima_ui/lib/screens/weather_screen.dart
@@ -122,43 +122,45 @@ class WeatherScreen extends HookConsumerWidget {
             await fullWeatherStateNotifier.loadFullWeather();
           }
         },
-        title: Row(
-          children: [
-            Text(
-              fullWeather == null
-                  ? ''
-                  : 'Updated ${DateFormat.Md().add_jm().format(fullWeather.currentWeather.date.toLocal())} · ',
-              style: TextStyle(
-                color: Theme.of(context).textTheme.subtitle2!.color,
-                fontSize:
-                    MediaQuery.of(context).size.shortestSide < kTabletBreakpoint
-                        ? 11.sp
-                        : 5.sp,
-              ),
-            ),
-            Text(
-              () {
-                switch (unitSystem) {
-                  case UnitSystem.metric:
-                    return '°C';
+        title: fullWeather == null
+            // If we use `null` here, it would show the hint. We want it to
+            // show nothing.
+            ? const SizedBox.shrink()
+            : Row(
+                children: [
+                  Text(
+                    'Updated ${DateFormat.Md().add_jm().format(fullWeather.currentWeather.date.toLocal())} · ',
+                    style: TextStyle(
+                      color: Theme.of(context).textTheme.subtitle2!.color,
+                      fontSize: MediaQuery.of(context).size.shortestSide <
+                              kTabletBreakpoint
+                          ? 11.sp
+                          : 5.sp,
+                    ),
+                  ),
+                  Text(
+                    () {
+                      switch (unitSystem) {
+                        case UnitSystem.metric:
+                          return '°C';
 
-                  case UnitSystem.imperial:
-                    return '°F';
+                        case UnitSystem.imperial:
+                          return '°F';
 
-                  case null:
-                    return '';
-                }
-              }(),
-              style: TextStyle(
-                color: Theme.of(context).textTheme.subtitle1!.color,
-                fontSize:
-                    MediaQuery.of(context).size.shortestSide < kTabletBreakpoint
-                        ? 11.sp
-                        : 5.sp,
+                        case null:
+                          return '';
+                      }
+                    }(),
+                    style: TextStyle(
+                      color: Theme.of(context).textTheme.subtitle1!.color,
+                      fontSize: MediaQuery.of(context).size.shortestSide <
+                              kTabletBreakpoint
+                          ? 11.sp
+                          : 5.sp,
+                    ),
+                  ),
+                ],
               ),
-            ),
-          ],
-        ),
         hint: 'Enter city name',
         color: Theme.of(context).appBarTheme.backgroundColor,
         transitionCurve: Curves.easeInOut,


### PR DESCRIPTION
<!-- Template adapted from https://github.com/auth0/open-source-template/blob/master/.github/PULL_REQUEST_TEMPLATE.md -->

<!-- Text between these brackets isn't actually shown to others. Check the preview if you're not sure! -->

<!-- By submitting a PR to this repository, you agree to the terms within our Code of Conduct (https://github.com/lacerte/clima/blob/master/CODE-OF-CONDUCT.md). Please see https://github.com/lacerte/clima/blob/master/CONTRIBUTING.md for how to create and submit a high-quality PR for this repo. -->

### Description
Don't show temperature unit in the app bar if the weather is `null`.
<!--
Describe this PR's purpose and impact, along with any background information. Please do not assume prior context.

Provide details that support your chosen implementation, including: breaking changes, alternatives considered, changes to the API, etc. If the UI is being changed, please provide screenshots.
--> 

### Testing

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this repository has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.

Please include any manual steps for testing any functionality not covered by unit/integration tests.

Also include details of the environment this PR was developed in (device/platform/version).
-->
Tested and confirmed to be working.
- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] The correct base branch is being used, if not `master`
