### PR TITLE
[ui] don't include `device_preview` by default

### DIFF
--- a/packages/clima_ui/lib/main_debug.dart
+++ b/packages/clima_ui/lib/main_debug.dart
@@ -1,0 +1,9 @@
+import 'package:device_preview/device_preview.dart';
+
+import 'main.dart' as m;
+
+Future<void> main() => m.main(
+      builder: DevicePreview.appBuilder,
+      topLevelBuilder: (widget) => DevicePreview(builder: (_) => widget),
+      getLocale: DevicePreview.locale,
+    );


### PR DESCRIPTION
<!-- Template adapted from https://github.com/auth0/open-source-template/blob/master/.github/PULL_REQUEST_TEMPLATE.md -->

<!-- Text between these brackets isn't actually shown to others. Check the preview if you're not sure! -->

<!-- By submitting a PR to this repository, you agree to the terms within our Code of Conduct (https://github.com/lacerte/clima/blob/master/CODE-OF-CONDUCT.md). Please see https://github.com/lacerte/clima/blob/master/CONTRIBUTING.md for how to create and submit a high-quality PR for this repo. -->

### Description

<!--
Describe this PR's purpose and impact, along with any background information. Please do not assume prior context.

Provide details that support your chosen implementation, including: breaking changes, alternatives considered, changes to the API, etc. If the UI is being changed, please provide screenshots.
--> 
Don't include `device_preview` by default.

Now if you run/build the app you get the version without `device_preview`. If you want `device_preview` you can pass `-t lib/main_debug.dart` to the command you're running, like so:

```console
$ flutter run # this runs the version without `device_preview`
$ flutter run -t lib/main_debug.dart # this runs the version with `device_preview`
```

I found that this reduces the release APK size by approximately 6%.

### Testing

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this repository has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.

Please include any manual steps for testing any functionality not covered by unit/integration tests.

Also include details of the environment this PR was developed in (device/platform/version).
-->
Tested manually.
- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] The correct base branch is being used, if not `master`
