### PR TITLE
Add call limit failure and show it in UI

### DIFF
--- a/packages/clima_core/lib/failure.dart
+++ b/packages/clima_core/lib/failure.dart
@@ -48,3 +48,10 @@ class InvalidApiKey extends Failure {
   @override
   List<Object?> get props => const [];
 }
+
+class CallLimitExceeded extends Failure {
+  const CallLimitExceeded();
+
+  @override
+  List<Object?> get props => const [];
+}

--- a/packages/clima_data/lib/data_sources/full_weather_remote_data_source.dart
+++ b/packages/clima_data/lib/data_sources/full_weather_remote_data_source.dart
@@ -61,6 +61,8 @@ class FullWeatherRemoteDataSource {
       return const Left(ServerDown());
     } else if (response.statusCode == 404) {
       return Left(InvalidCityName(city.name));
+    } else if (response.statusCode == 429) {
+      return const Left(CallLimitExceeded());
     } else {
       // TODO: I don't think this failure is fit for this situation.
       return const Left(FailedToParseResponse());

--- a/packages/clima_data/lib/data_sources/geocoding_remote_data_source.dart
+++ b/packages/clima_data/lib/data_sources/geocoding_remote_data_source.dart
@@ -38,8 +38,12 @@ class GeocodingRemoteDataSource {
       ),
     );
 
-    if (response.statusCode == 503) {
-      return const Left(ServerDown());
+    switch (response.statusCode) {
+      case 503:
+        return const Left(ServerDown());
+
+      case 429:
+        return const Left(CallLimitExceeded());
     }
 
     dynamic body;

--- a/packages/clima_ui/lib/utilities/snack_bars.dart
+++ b/packages/clima_ui/lib/utilities/snack_bars.dart
@@ -22,6 +22,8 @@ void showFailureSnackBar(
       return "Can't connect to server";
     } else if (failure is InvalidCityName) {
       return 'Invalid city name';
+    } else if (failure is CallLimitExceeded) {
+      return 'API key call limit reached';
     } else {
       throw ArgumentError('Did not expect $failure');
     }

--- a/packages/clima_ui/lib/widgets/others/failure_banner.dart
+++ b/packages/clima_ui/lib/widgets/others/failure_banner.dart
@@ -34,6 +34,8 @@ class FailureBanner extends HookWidget {
             return 'Looks like an invalid city name. Please check it and try again.';
           } else if (failure is InvalidApiKey) {
             return "Looks like the API key being used isn't valid, probably because it expired. Please fix the issue and try again.";
+          } else if (failure is CallLimitExceeded) {
+            return "Looks like you reached the API key's call limit. Please try again later.";
           } else {
             throw ArgumentError('Did not expect $failure');
           }


### PR DESCRIPTION
<!-- Template adapted from https://github.com/auth0/open-source-template/blob/master/.github/PULL_REQUEST_TEMPLATE.md -->

<!-- Text between these brackets isn't actually shown to others. Check the preview if you're not sure! -->

<!-- By submitting a PR to this repository, you agree to the terms within our Code of Conduct (https://github.com/lacerte/clima/blob/master/CODE-OF-CONDUCT.md). Please see https://github.com/lacerte/clima/blob/master/CONTRIBUTING.md for how to create and submit a high-quality PR for this repo. -->

### Description
Add a `CallLimitExceeded` failure, and handle it in the UI.
<!--
Describe this PR's purpose and impact, along with any background information. Please do not assume prior context.

Provide details that support your chosen implementation, including: breaking changes, alternatives considered, changes to the API, etc. If the UI is being changed, please provide screenshots.
--> 

### References
- https://openweathermap.org/faq (search for 429)
<!-- Include any relevant links here, like GitHub issues or Stack Overflow posts. Feel free to delete this section if there are no references. -->

### Testing
I have no idea how we should test this. Thoughts?
<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this repository has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.

Please include any manual steps for testing any functionality not covered by unit/integration tests.

Also include details of the environment this PR was developed in (device/platform/version).
-->
[app-release.zip](https://github.com/Lacerte/clima/files/8056420/app-release.zip)

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] The correct base branch is being used, if not `master`
