### PR TITLE
Add boucing physics to hourly forecast

### DIFF
--- a/packages/clima_ui/lib/widgets/weather/hourly_forecasts_widget.dart
+++ b/packages/clima_ui/lib/widgets/weather/hourly_forecasts_widget.dart
@@ -32,6 +32,7 @@ class HourlyForecastsWidget extends ConsumerWidget {
 
     return ListView.separated(
       scrollDirection: Axis.horizontal,
+      physics: const BouncingScrollPhysics(),
       shrinkWrap: true,
       itemCount: 24,
       separatorBuilder: (context, index) => const Divider(),


### PR DESCRIPTION


<!-- Template adapted from https://github.com/auth0/open-source-template/blob/master/.github/PULL_REQUEST_TEMPLATE.md -->

<!-- Text between these brackets isn't actually shown to others. Check the preview if you're not sure! -->

<!-- By submitting a PR to this repository, you agree to the terms within our Code of Conduct (https://github.com/lacerte/clima/blob/master/CODE-OF-CONDUCT.md). Please see https://github.com/lacerte/clima/blob/master/CONTRIBUTING.md for how to create and submit a high-quality PR for this repo. -->

### Description
Very small commit, but added bouncing physics for more consistency with the rest of the weather page, which has vertical bouncing physics only. This adds it to the hourly forecast which scrolls horizontally.
<!--
Describe this PR's purpose and impact, along with any background information. Please do not assume prior context.

Provide details that support your chosen implementation, including: breaking changes, alternatives considered, changes to the API, etc. If the UI is being changed, please provide screenshots.
--> 

### Testing

![ezgif-4-91ee772f0f](https://user-images.githubusercontent.com/43153657/156479769-07a27f2e-6512-42dd-a2f4-46603134a7a1.gif)

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this repository has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.

Please include any manual steps for testing any functionality not covered by unit/integration tests.

Also include details of the environment this PR was developed in (device/platform/version).
-->

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] The correct base branch is being used, if not `master`
