### PR TITLE
[ui] add build flavors

### DIFF
--- a/packages/clima_ui/lib/build_flavor.dart
+++ b/packages/clima_ui/lib/build_flavor.dart
@@ -1,0 +1,17 @@
+enum BuildFlavor { default_, googlePlay }
+
+const _buildFlavorString = bool.hasEnvironment('buildFlavor')
+    ? String.fromEnvironment('buildFlavor')
+    : null;
+
+const buildFlavor = _buildFlavorString == 'googleplay'
+    ? BuildFlavor.googlePlay
+    : BuildFlavor.default_;
+
+void validateBuildFlavor() {
+  if (_buildFlavorString != 'googleplay' && _buildFlavorString != null) {
+    throw Exception(
+      'Invalid flavor $_buildFlavorString, valid flavors: googleplay',
+    );
+  }
+}

--- a/packages/clima_ui/lib/main.dart
+++ b/packages/clima_ui/lib/main.dart
@@ -26,6 +26,7 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:sizer/sizer.dart';
 
+import 'build_flavor.dart';
 import 'themes/clima_theme.dart';
 
 Future<void> main({
@@ -67,6 +68,8 @@ class _App extends HookConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    validateBuildFlavor();
+
     final themeStateNotifier = ref.watch(themeStateNotifierProvider.notifier);
 
     useEffect(

--- a/packages/clima_ui/lib/screens/about_screen.dart
+++ b/packages/clima_ui/lib/screens/about_screen.dart
@@ -4,6 +4,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
+import 'package:clima_ui/build_flavor.dart';
 import 'package:clima_ui/widgets/dialogs/credits_dialog.dart';
 import 'package:clima_ui/widgets/dialogs/help_and_feedback_dialog.dart';
 import 'package:clima_ui/widgets/settings/settings_divider.dart';
@@ -52,17 +53,20 @@ class AboutScreen extends StatelessWidget {
                 'https://github.com/lacerte/clima/releases/tag/v2.0.0',
               ),
             ),
-            SettingsTile(
-              title: 'Donate',
-              subtitle: 'Support the development of Clima',
-              leading: Icon(
-                Icons.local_library_outlined,
-                color: Theme.of(context).iconTheme.color,
+            // Google doesn't like donate buttons apparently. Stupid, I know.
+            // Example: https://github.com/streetcomplete/StreetComplete/issues/3768
+            if (buildFlavor != BuildFlavor.googlePlay)
+              SettingsTile(
+                title: 'Donate',
+                subtitle: 'Support the development of Clima',
+                leading: Icon(
+                  Icons.local_library_outlined,
+                  color: Theme.of(context).iconTheme.color,
+                ),
+                onTap: () => launch(
+                  'https://liberapay.com/lacerte/donate',
+                ),
               ),
-              onTap: () => launch(
-                'https://liberapay.com/lacerte/donate',
-              ),
-            ),
             SettingsTile(
               title: 'Libraries',
               subtitle: 'Open-source libraries used in the app',


### PR DESCRIPTION
<!-- Template adapted from https://github.com/auth0/open-source-template/blob/master/.github/PULL_REQUEST_TEMPLATE.md -->

<!-- Text between these brackets isn't actually shown to others. Check the preview if you're not sure! -->

<!-- By submitting a PR to this repository, you agree to the terms within our Code of Conduct (https://github.com/lacerte/clima/blob/master/CODE-OF-CONDUCT.md). Please see https://github.com/lacerte/clima/blob/master/CONTRIBUTING.md for how to create and submit a high-quality PR for this repo. -->

### Description
Supersedes #279.

To choose a flavor, just pass `--dart-define=buildFlavor=$FLAVOR` to `flutter build` or `flutter run`, or you get the "default" flavor if you don't pass it. Currently, you can only pass `googleplay` as `$FLAVOR`; more may be added in the future.

There is also a runtime check for the flavor, for extra safety.

Additionally, the PR demonstrates how to change behavior based on the flavor by hiding the donation button when using the Google Play flavor, because Google doesn't like such things apparently.
<!--
Describe this PR's purpose and impact, along with any background information. Please do not assume prior context.

Provide details that support your chosen implementation, including: breaking changes, alternatives considered, changes to the API, etc. If the UI is being changed, please provide screenshots.
--> 

### Testing

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this repository has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.

Please include any manual steps for testing any functionality not covered by unit/integration tests.

Also include details of the environment this PR was developed in (device/platform/version).
-->
Try out `flutter build`/`flutter run` with `--dart-define=buildFlavor=googleplay` and without passing any build flavor at all, and ensure that the app uses the behavior appropriate to that flavor (currently, just check if the donation tile is present in the about page). Also try with invalid flavors to ensure the runtime check works.

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] The correct base branch is being used, if not `master`
