### PR TITLE
Fix API key reset not working

### DIFF
--- a/packages/clima_ui/lib/widgets/dialogs/api_key/api_key_reset_dialog.dart
+++ b/packages/clima_ui/lib/widgets/dialogs/api_key/api_key_reset_dialog.dart
@@ -1,10 +1,14 @@
+import 'package:clima_data/models/api_key_model.dart';
+import 'package:clima_ui/state_notifiers/api_key_state_notifier.dart';
+import 'package:clima_ui/utilities/snack_bars.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-class ApiKeyResetDialog extends StatelessWidget {
+class ApiKeyResetDialog extends ConsumerWidget {
   const ApiKeyResetDialog({Key? key}) : super(key: key);
 
   @override
-  Widget build(BuildContext context) => AlertDialog(
+  Widget build(BuildContext context, WidgetRef ref) => AlertDialog(
         title: Text(
           'Reset API Key?',
           style: TextStyle(
@@ -24,7 +28,15 @@ class ApiKeyResetDialog extends StatelessWidget {
             ),
           ),
           TextButton(
-            onPressed: () {
+            onPressed: () async {
+              await ref
+                  .read(apiKeyStateNotifierProvider.notifier)
+                  .setApiKey(const ApiKeyModel.default_());
+              showSnackBar(
+                context,
+                text: 'API key reset successfully.',
+                duration: 4,
+              );
               Navigator.pop(context);
             },
             child: Text(


### PR DESCRIPTION
<!-- Template adapted from https://github.com/auth0/open-source-template/blob/master/.github/PULL_REQUEST_TEMPLATE.md -->

<!-- Text between these brackets isn't actually shown to others. Check the preview if you're not sure! -->

<!-- By submitting a PR to this repository, you agree to the terms within our Code of Conduct (https://github.com/lacerte/clima/blob/master/CODE-OF-CONDUCT.md). Please see https://github.com/lacerte/clima/blob/master/CONTRIBUTING.md for how to create and submit a high-quality PR for this repo. -->

### Description

Fix API key reset not working. We forgot to actually implement this and released a non-working API key reset feature in Clima 2.0.0, which is a BIG blunder.

<!--
Describe this PR's purpose and impact, along with any background information. Please do not assume prior context.

Provide details that support your chosen implementation, including: breaking changes, alternatives considered, changes to the API, etc. If the UI is being changed, please provide screenshots.
--> 

### References

<!-- Include any relevant links here, like GitHub issues or Stack Overflow posts. Feel free to delete this section if there are no references. -->

### Testing

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this repository has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.

Please include any manual steps for testing any functionality not covered by unit/integration tests.

Also include details of the environment this PR was developed in (device/platform/version).
-->
Test the APK.

### Checklist

- [x] The correct base branch is being used, if not `master`
