### PR TITLE
[ui] remove deprecated options from `gradle.properties`

### DIFF
--- a/packages/clima_ui/android/gradle.properties
+++ b/packages/clima_ui/android/gradle.properties
@@ -1,5 +1,3 @@
 android.useAndroidX=true
 android.enableJetifier=true
 org.gradle.jvmargs=-Xmx1536M
-android.enableR8=true
-android.bundle.enableUncompressedNativeLibs=false


### PR DESCRIPTION

<!-- Template adapted from https://github.com/auth0/open-source-template/blob/master/.github/PULL_REQUEST_TEMPLATE.md -->

<!-- Text between these brackets isn't actually shown to others. Check the preview if you're not sure! -->

<!-- By submitting a PR to this repository, you agree to the terms within our Code of Conduct (https://github.com/lacerte/clima/blob/master/CODE-OF-CONDUCT.md). Please see https://github.com/lacerte/clima/blob/master/CONTRIBUTING.md for how to create and submit a high-quality PR for this repo. -->

### Description

Remove two deprecated options from `gradle.properties`. R8 is enabled by default now, and `useLegacyPackaging true` in `android/app/build.gradle` replaces `android.bundle.enableUncompressedNativeLibs=false`.

<!--
Describe this PR's purpose and impact, along with any background information. Please do not assume prior context.

Provide details that support your chosen implementation, including: breaking changes, alternatives considered, changes to the API, etc. If the UI is being changed, please provide screenshots.
--> 

### References

<!-- Include any relevant links here, like GitHub issues or Stack Overflow posts. Feel free to delete this section if there are no references. -->

### Testing
Just build an APK.
<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this repository has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.

Please include any manual steps for testing any functionality not covered by unit/integration tests.

Also include details of the environment this PR was developed in (device/platform/version).
-->

### Checklist

- [x] The correct base branch is being used, if not `master`
