### PR TITLE
[ui] a couple of snackbar fixes

### DIFF
--- a/packages/clima_ui/lib/utilities/snack_bars.dart
+++ b/packages/clima_ui/lib/utilities/snack_bars.dart
@@ -34,6 +34,7 @@ void showFailureSnackBar(
     text: text,
     actionText: 'Retry',
     onPressed: onRetry,
+    duration: duration,
   );
 }
 
@@ -51,7 +52,7 @@ void showSnackBar(
       elevation: 0,
       behavior: SnackBarBehavior.floating,
       content: Text(text),
-      duration: Duration(seconds: duration ?? 86400),
+      duration: Duration(seconds: duration ?? 4),
       action: onPressed != null
           ? SnackBarAction(
               label: actionText!,

--- a/packages/clima_ui/lib/widgets/dialogs/api_key/api_key_dialog.dart
+++ b/packages/clima_ui/lib/widgets/dialogs/api_key/api_key_dialog.dart
@@ -38,11 +38,7 @@ class ApiKeyDialog extends HookConsumerWidget {
     ref.listen<ApiKeyState>(apiKeyStateNotifierProvider, (prev, next) {
       if (next is Loaded) {
         Navigator.pop(context);
-        showSnackBar(
-          context,
-          text: 'API key updated successfully.',
-          duration: 4,
-        );
+        showSnackBar(context, text: 'API key updated successfully.');
       }
     });
 

--- a/packages/clima_ui/lib/widgets/dialogs/api_key/api_key_reset_dialog.dart
+++ b/packages/clima_ui/lib/widgets/dialogs/api_key/api_key_reset_dialog.dart
@@ -32,11 +32,7 @@ class ApiKeyResetDialog extends ConsumerWidget {
               await ref
                   .read(apiKeyStateNotifierProvider.notifier)
                   .setApiKey(const ApiKeyModel.default_());
-              showSnackBar(
-                context,
-                text: 'API key reset successfully.',
-                duration: 4,
-              );
+              showSnackBar(context, text: 'API key reset successfully.');
               Navigator.pop(context);
             },
             child: Text(


### PR DESCRIPTION
<!-- Template adapted from https://github.com/auth0/open-source-template/blob/master/.github/PULL_REQUEST_TEMPLATE.md -->

<!-- Text between these brackets isn't actually shown to others. Check the preview if you're not sure! -->

<!-- By submitting a PR to this repository, you agree to the terms within our Code of Conduct (https://github.com/lacerte/clima/blob/master/CODE-OF-CONDUCT.md). Please see https://github.com/lacerte/clima/blob/master/CONTRIBUTING.md for how to create and submit a high-quality PR for this repo. -->

### Description

- Fix `duration` passed to `showFailureSnackBar` being ignored
- Change default snackbar duration to 4 seconds


<!--
Describe this PR's purpose and impact, along with any background information. Please do not assume prior context.

Provide details that support your chosen implementation, including: breaking changes, alternatives considered, changes to the API, etc. If the UI is being changed, please provide screenshots.
--> 

### Testing

Test snackbars by e.g. entering an invalid city name. The snackbar used to show for a whole day, but it shouldn't with this PR's changes.

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this repository has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.

Please include any manual steps for testing any functionality not covered by unit/integration tests.

Also include details of the environment this PR was developed in (device/platform/version).
-->

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] The correct base branch is being used, if not `master`
