### PR TITLE
[ci] fix YAML syntax errors in Github workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,16 +44,16 @@ jobs:
         working-directory: ${{ matrix.package }}
 
       - name: Get packages
-        run: "$command" pub get
+        run: '"$command" pub get'
         working-directory: ${{ matrix.package }}
 
       - name: Run code generation
-        run: "$command" pub run build_runner build
+        run: '"$command" pub run build_runner build'
         working-directory: ${{ matrix.package }}
         if: ${{ endsWith(matrix.package, 'data') }}
 
       - name: Analyze source code
-        run: "$command" analyze
+        run: '"$command" analyze'
         working-directory: ${{ matrix.package }}
 
       - name: Run tests


### PR DESCRIPTION
<!-- Template adapted from https://github.com/auth0/open-source-template/blob/master/.github/PULL_REQUEST_TEMPLATE.md -->

<!-- Text between these brackets isn't actually shown to others. Check the preview if you're not sure! -->

<!-- By submitting a PR to this repository, you agree to the terms within our Code of Conduct (https://github.com/lacerte/clima/blob/master/CODE-OF-CONDUCT.md). Please see https://github.com/lacerte/clima/blob/master/CONTRIBUTING.md for how to create and submit a high-quality PR for this repo. -->

### Description
Fix CI not actually running.

The issue was introduced in https://github.com/Lacerte/clima/pull/312.

### Testing

The CI should run properly.

### Checklist

- [x] The correct base branch is being used, if not `master`
