### PR TITLE
Move the unit system to the main info

### DIFF
--- a/.builds/android.yml
+++ b/.builds/android.yml
@@ -1,0 +1,43 @@
+# Copied and adapted from https://git.sr.ht/~emersion/goguma/tree/master/item/.builds/android.yml
+# See https://git.sr.ht/~emersion/goguma/tree/master/item/LICENSE
+
+image: archlinux
+packages:
+  - android-platform
+  - android-sdk
+  - android-sdk-build-tools
+  - android-sdk-cmdline-tools-latest
+  - android-sdk-platform-tools
+  - flutter
+  - jdk11-openjdk
+  - curl
+  - unzip
+sources:
+  - https://git.sr.ht/~whynothugo/clima
+# secrets:
+#   - XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX # keystore.jks
+#   - XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX # keystore.properties
+artifacts:
+  - clima/packages/clima_ui/build/app/outputs/flutter-apk/app-release.apk
+tasks:
+  - setup-tools: |
+      sudo chown -R $USER /opt/flutter /opt/android-sdk
+      source /etc/profile
+      flutter precache --linux
+      yes | flutter doctor --android-licenses >/dev/null
+      flutter doctor -v
+  # - configure: |
+  #     cd clima/packages/clima_ui/
+  #     ln -s ~/keystore.properties android/keystore.properties
+  #     ln -s ~/keystore.jks android/keystore.jks
+  - patch: |
+      cd clima
+      curl -LO https://github.com/Lacerte/clima/files/8626116/patch.zip
+      unzip patch.zip
+      git apply 0001-Use-debug-signing-keys.patch
+  - build: |
+      cd clima/packages/clima_ui/
+      flutter build apk --build-number="$(git rev-list --first-parent --count HEAD)"
+ # - analyze: |
+ #     cd clima
+ #     flutter analyze --no-fatal-infos

--- a/packages/clima_ui/lib/screens/weather_screen.dart
+++ b/packages/clima_ui/lib/screens/weather_screen.dart
@@ -126,40 +126,15 @@ class WeatherScreen extends HookConsumerWidget {
             // If we use `null` here, it would show the hint. We want it to
             // show nothing.
             ? const SizedBox.shrink()
-            : Row(
-                children: [
-                  Text(
-                    'Updated ${DateFormat.Md().add_jm().format(fullWeather.currentWeather.date.toLocal())} · ',
-                    style: TextStyle(
-                      color: Theme.of(context).textTheme.subtitle2!.color,
-                      fontSize: MediaQuery.of(context).size.shortestSide <
-                              kTabletBreakpoint
-                          ? 11.sp
-                          : 5.sp,
-                    ),
-                  ),
-                  Text(
-                    () {
-                      switch (unitSystem) {
-                        case UnitSystem.metric:
-                          return '°C';
-
-                        case UnitSystem.imperial:
-                          return '°F';
-
-                        case null:
-                          return '';
-                      }
-                    }(),
-                    style: TextStyle(
-                      color: Theme.of(context).textTheme.subtitle1!.color,
-                      fontSize: MediaQuery.of(context).size.shortestSide <
-                              kTabletBreakpoint
-                          ? 11.sp
-                          : 5.sp,
-                    ),
-                  ),
-                ],
+            : Text(
+                'Updated ${DateFormat.Md().add_jm().format(fullWeather.currentWeather.date.toLocal())}',
+                style: TextStyle(
+                  color: Theme.of(context).textTheme.subtitle2!.color,
+                  fontSize: MediaQuery.of(context).size.shortestSide <
+                          kTabletBreakpoint
+                      ? 11.sp
+                      : 5.sp,
+                ),
               ),
         hint: 'Enter city name',
         color: Theme.of(context).appBarTheme.backgroundColor,

--- a/packages/clima_ui/lib/widgets/weather/main_info_widget.dart
+++ b/packages/clima_ui/lib/widgets/weather/main_info_widget.dart
@@ -99,8 +99,8 @@ class MainInfoWidget extends ConsumerWidget {
                   style: kSubtitle1TextStyle(context).copyWith(
                     fontSize:
                         MediaQuery.of(context).size.shortestSide < kTabletBreakpoint
-                            ? 40.sp
-                            : 30.sp,
+                            ? 30.sp
+                            : 25.sp,
                     fontWeight: FontWeight.w100,
                   ),
                 ),

--- a/packages/clima_ui/lib/widgets/weather/main_info_widget.dart
+++ b/packages/clima_ui/lib/widgets/weather/main_info_widget.dart
@@ -71,6 +71,7 @@ class MainInfoWidget extends ConsumerWidget {
             padding: EdgeInsets.only(bottom: 1.h),
             child: Row(
               mainAxisAlignment: MainAxisAlignment.center,
+              crossAxisAlignment: CrossAxisAlignment.baseline,
               children: [
                 Text(
                   '${currentWeather.temperature.round()}°',

--- a/packages/clima_ui/lib/widgets/weather/main_info_widget.dart
+++ b/packages/clima_ui/lib/widgets/weather/main_info_widget.dart
@@ -4,7 +4,9 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
+import 'package:clima_domain/entities/unit_system.dart';
 import 'package:clima_ui/state_notifiers/full_weather_state_notifier.dart' as w;
+import 'package:clima_ui/state_notifiers/unit_system_state_notifier.dart' as u;
 import 'package:clima_ui/utilities/constants.dart';
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
@@ -29,6 +31,9 @@ class MainInfoWidget extends ConsumerWidget {
       w.fullWeatherStateNotifierProvider.select(
         (state) => state.fullWeather!.city,
       ),
+    );
+    final unitSystem = ref.watch(
+      u.unitSystemStateNotifierProvider.select((state) => state.unitSystem),
     );
 
     return Padding(
@@ -64,16 +69,42 @@ class MainInfoWidget extends ConsumerWidget {
           ),
           Padding(
             padding: EdgeInsets.only(bottom: 1.h),
-            child: Text(
-              '${currentWeather.temperature.round()}°',
-              maxLines: 1,
-              style: kSubtitle1TextStyle(context).copyWith(
-                fontSize:
-                    MediaQuery.of(context).size.shortestSide < kTabletBreakpoint
-                        ? 40.sp
-                        : 30.sp,
-                fontWeight: FontWeight.w100,
-              ),
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                Text(
+                  '${currentWeather.temperature.round()}°',
+                  maxLines: 1,
+                  style: kSubtitle1TextStyle(context).copyWith(
+                    fontSize:
+                        MediaQuery.of(context).size.shortestSide < kTabletBreakpoint
+                            ? 50.sp
+                            : 40.sp,
+                    fontWeight: FontWeight.w100,
+                  ),
+                ),
+                Text(
+                  () {
+                    switch (unitSystem) {
+                      case UnitSystem.metric:
+                        return 'C';
+
+                      case UnitSystem.imperial:
+                        return 'F';
+
+                      case null:
+                        return '';
+                    }
+                  }(),
+                  style: kSubtitle1TextStyle(context).copyWith(
+                    fontSize:
+                        MediaQuery.of(context).size.shortestSide < kTabletBreakpoint
+                            ? 40.sp
+                            : 30.sp,
+                    fontWeight: FontWeight.w100,
+                  ),
+                ),
+              ]
             ),
           ),
           Padding(


### PR DESCRIPTION
Hi! This is about 90% done, but my Android phone died before the last round of polish, so opening this PR in case someone wants to pick up.

85e3994f0183a10e2df43d0da0d4933ef3c8a54b moves the unit system label next to the current temperature. It's a lot more contextual, balances content more into the main temperature display, and unclutters the top bit.

cf83f3ac35875b0c6905492af5a51a7c62f261ae should probably be squashed; it makes the unit a bit smaller, which looks good. The problem is it's no vertically aligned on the baseline, but on centered, which just looks wrong.

dd571441c4d64831118379908d291f05094601e0 tried to fix this, but just renders blank. My phone died a couple of days after, so I never go around to figuring out what was wrong.

