### PR TITLE
[ui] remove `package_info_plus` dependency

### DIFF
--- a/lib/constants.dart
+++ b/lib/constants.dart
@@ -1,0 +1,7 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+const appVersion = '2.0.1';

--- a/lib/ui/screens/about_screen.dart
+++ b/lib/ui/screens/about_screen.dart
@@ -4,6 +4,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
+import 'package:clima/constants.dart';
 import 'package:clima/ui/build_flavor.dart';
 import 'package:clima/ui/widgets/dialogs/credits_dialog.dart';
 import 'package:clima/ui/widgets/dialogs/help_and_feedback_dialog.dart';
@@ -12,7 +13,6 @@ import 'package:clima/ui/widgets/settings/settings_header.dart';
 import 'package:clima/ui/widgets/settings/settings_tile.dart';
 import 'package:flutter/material.dart';
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
-import 'package:package_info_plus/package_info_plus.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 class AboutScreen extends StatelessWidget {
@@ -43,14 +43,14 @@ class AboutScreen extends StatelessWidget {
               ),
               SettingsTile(
                 title: 'Changelog',
-                subtitle: 'Version 2.0.1',
+                subtitle: 'Version $appVersion',
                 leading: Icon(
                   Icons.new_releases_outlined,
                   color: Theme.of(context).iconTheme.color,
                 ),
                 onTap: () => launchUrl(
                   Uri.parse(
-                    'https://github.com/lacerte/clima/releases/tag/v2.0.1',
+                    'https://github.com/lacerte/clima/releases/tag/v$appVersion',
                   ),
                 ),
               ),
@@ -75,13 +75,11 @@ class AboutScreen extends StatelessWidget {
                   Icons.source_outlined,
                   color: Theme.of(context).iconTheme.color,
                 ),
-                onTap: () async {
-                  final PackageInfo packageInfo =
-                      await PackageInfo.fromPlatform();
+                onTap: () {
                   showLicensePage(
                     context: context,
-                    applicationName: packageInfo.appName,
-                    applicationVersion: packageInfo.version,
+                    applicationName: 'Clima',
+                    applicationVersion: appVersion,
                   );
                 },
               ),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -478,48 +478,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.0"
-  package_info_plus:
-    dependency: "direct main"
-    description:
-      name: package_info_plus
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.4.2"
-  package_info_plus_linux:
-    dependency: transitive
-    description:
-      name: package_info_plus_linux
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.0.5"
-  package_info_plus_macos:
-    dependency: transitive
-    description:
-      name: package_info_plus_macos
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.3.0"
-  package_info_plus_platform_interface:
-    dependency: transitive
-    description:
-      name: package_info_plus_platform_interface
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.0.2"
-  package_info_plus_web:
-    dependency: transitive
-    description:
-      name: package_info_plus_web
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.0.5"
-  package_info_plus_windows:
-    dependency: transitive
-    description:
-      name: package_info_plus_windows
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.0.5"
   path:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,7 +20,6 @@ dependencies:
     git:
       url: https://github.com/CentaurusApps/material_floating_search_bar.git
       ref: 07b2980ad304dacaa5688e56483adcec36fb08ab
-  package_info_plus: 1.4.2
   riverpod: 1.0.3
   shared_preferences: 2.0.15
   font_awesome_flutter: 10.1.0


### PR DESCRIPTION
<!-- Template adapted from https://github.com/auth0/open-source-template/blob/master/.github/PULL_REQUEST_TEMPLATE.md -->

<!-- Text between these brackets isn't actually shown to others. Check the preview if you're not sure! -->

<!-- By submitting a PR to this repository, you agree to the terms within our Code of Conduct (https://github.com/lacerte/clima/blob/master/CODE-OF-CONDUCT.md). Please see https://github.com/lacerte/clima/blob/master/CONTRIBUTING.md for how to create and submit a high-quality PR for this repo. -->

### Description
Remove `package_info_plus` dependency.

Benefits:
- Fewer dependencies (yay!)
- We now need to update the app version on new releases only in two places: `pubspec.yaml` and `lib/constants.dart`. I plan to create a release guide so we don't forget either when creating a new release (see https://github.com/Lacerte/clima/issues/285).

<!--
Describe this PR's purpose and impact, along with any background information. Please do not assume prior context.

Provide details that support your chosen implementation, including: breaking changes, alternatives considered, changes to the API, etc. If the UI is being changed, please provide screenshots.
-->

### Testing

Run the app and check the following:
- The app version in the about and libraries pages is correct
- When you press on the changelog list tile, it opens the correct GitHub release
- The libraries page has "Clima" as the app name

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this repository has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.

Please include any manual steps for testing any functionality not covered by unit/integration tests.

Also include details of the environment this PR was developed in (device/platform/version).
-->

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] The correct base branch is being used, if not `master`
